### PR TITLE
Fixes the linked list example

### DIFF
--- a/examples/linked_list.ae
+++ b/examples/linked_list.ae
@@ -28,7 +28,7 @@ def Node::print_list(&this) {
 }
 
 def main() {
-    let head = null
+    let head = Node::new(0)
     head = head.add_front(1)
     head = head.add_front(2)
     head = head.add_front(4)


### PR DESCRIPTION
Linked list example was giving an error.

Before:
```
--------------------------------------------------------------------------------
./.\test.ae:30:10: Error: LHS of member access must be a struct / string
--------------------------------------------------------------------------------
  29 |   let head = null
  30 |   head = head.add_front(1)
                ^ LHS of member access must be a struct / string
  31 |   head = head.add_front(2)
--------------------------------------------------------------------------------
./.\test.ae:31:10: Error: LHS of member access must be a struct / string
--------------------------------------------------------------------------------
  30 |   head = head.add_front(1)
  31 |   head = head.add_front(2)
                ^ LHS of member access must be a struct / string
  32 |   head = head.add_front(4)
--------------------------------------------------------------------------------
./.\test.ae:32:10: Error: LHS of member access must be a struct / string
--------------------------------------------------------------------------------
  31 |   head = head.add_front(2)
  32 |   head = head.add_front(4)
                ^ LHS of member access must be a struct / string
  33 |   head = head.add_front(3)
--------------------------------------------------------------------------------
./.\test.ae:33:10: Error: LHS of member access must be a struct / string
--------------------------------------------------------------------------------
  32 |   head = head.add_front(4)
  33 |   head = head.add_front(3)
                ^ LHS of member access must be a struct / string
  34 |   head.print_list();
--------------------------------------------------------------------------------
./.\test.ae:34:3: Error: LHS of member access must be a struct / string
--------------------------------------------------------------------------------
  33 |   head = head.add_front(3)
  34 |   head.print_list();
         ^ LHS of member access must be a struct / string
  35 | }
  ```

After:
```
3 -> 4 -> 2 -> 1 -> 0 -> end
```